### PR TITLE
Prevent word wrap for multibyte characters

### DIFF
--- a/index.php
+++ b/index.php
@@ -1448,6 +1448,7 @@ function html_header($header=""){
         .table td.sm {
             width: 10px;
             padding: .3rem .6rem;
+            white-space: nowrap;
         }
         table.entry_name_table {
             width: 100%;


### PR DESCRIPTION
Due to the cell width, multibyte characters like Korean, Japanese, Chinese letters breaks the line by every single letter.
I don't think this is an ideal stylesheet but the simplest way to fix.